### PR TITLE
feat(KUI-1036): add handling of missing applicationCodes in postNewVersionOfPublishedMemo

### DIFF
--- a/server/controllers/memoDataCtrl.js
+++ b/server/controllers/memoDataCtrl.js
@@ -6,6 +6,7 @@
 const log = require('@kth/log')
 const dbOneDocument = require('../lib/dbDataById')
 const dbArrayOfDocument = require('../lib/dbSeveralDocument')
+const { InvalidDataError } = require('../utils/errorUtils')
 
 async function getMemoVersion(req, res) {
   const { courseCode, memoEndPoint, version } = req.params
@@ -54,7 +55,10 @@ async function postNewVersionOfPublishedMemo(req, res) {
     log.info('dbResponse length', dbResponse.length, { memoEndPoint })
     res.status(201).json(dbResponse)
   } catch (error) {
-    log.error('Error in while trying to postNewMemo ', { error })
+    log.error('Error while trying to postNewMemo ', { error })
+    if (error instanceof InvalidDataError) {
+      res.status(400).json(error.message)
+    }
     return error
   }
 }
@@ -97,7 +101,10 @@ async function putDraftByEndPoint(req, res) {
     log.info('dbResponse length', dbResponse.length, { memoEndPoint })
     res.status(201).json(dbResponse)
   } catch (error) {
-    log.error('Error in while trying to putDraftByEndPoint', { error })
+    log.error('Error while trying to putDraftByEndPoint', { error })
+    if (error instanceof InvalidDataError) {
+      res.status(400).json(error.message)
+    }
     return error
   }
 }
@@ -167,7 +174,10 @@ async function createDraftByMemoEndPoint(req, res) {
     log.info('dbResponse length', dbResponse.length, { memoEndPoint })
     res.status(201).json(dbResponse)
   } catch (error) {
-    log.error('Error in while trying to createDraftByMemoEndPoint ', { error })
+    log.error('Error while trying to createDraftByMemoEndPoint ', { error })
+    if (error instanceof InvalidDataError) {
+      res.status(400).json(error.message)
+    }
     return error
   }
 }

--- a/server/controllers/storedMemoPdfsCtrl.js
+++ b/server/controllers/storedMemoPdfsCtrl.js
@@ -63,7 +63,7 @@ async function checkLength(req, res) {
 
     res.status(201).json({ length: allmemos.length })
   } catch (error) {
-    log.error('Error in while trying to save all migrating memos ', { error })
+    log.error('Error while trying to save all migrating memos ', { error })
     return error
   }
 }

--- a/server/utils/errorUtils.js
+++ b/server/utils/errorUtils.js
@@ -1,0 +1,10 @@
+class InvalidDataError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'InvalidDataError'
+  }
+}
+
+module.exports = {
+  InvalidDataError,
+}


### PR DESCRIPTION
If postNewVersionOfPublishedMemo is called with a memoObject that 

1. does not exist in the database
2. does not contain any applicationCodes

it will return a status code 400 with error message to refresh/clear cache.